### PR TITLE
修复mac上下载视频后无法进行合并问题

### DIFF
--- a/src/nicelee/bilibili/util/CmdUtil.java
+++ b/src/nicelee/bilibili/util/CmdUtil.java
@@ -1,10 +1,6 @@
 package nicelee.bilibili.util;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.FilenameFilter;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -20,17 +16,14 @@ import nicelee.ui.thread.StreamManager;
 
 public class CmdUtil {
 
-	public static String FFMPEG_PATH = "ffmpeg";
-
 	public static boolean run(String cmd[]) {
-		Process process = null;
+		Process process;
 		try {
 			process = Runtime.getRuntime().exec(cmd);
 			StreamManager errorStream = new StreamManager(process, process.getErrorStream());
 			StreamManager outputStream = new StreamManager(process, process.getInputStream());
 			errorStream.start();
 			outputStream.start();
-			// System.out.println("此处堵塞, 直至process 执行完毕");
 			process.waitFor();
 			System.out.println("process 执行完毕");
 			return true;
@@ -73,7 +66,7 @@ public class CmdUtil {
 	 * 音视频合并转码
 	 * 
 	 * @param videoName
-	 * @param audioName
+	 * @param dstName
 	 * @param dstName
 	 */
 	public static boolean convert(String videoName, String dstName) {
@@ -192,7 +185,7 @@ public class CmdUtil {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-		String cmd[] = { FFMPEG_PATH, "-f", "concat", "-safe", "0", "-i", Global.savePath + dstName + ".txt", "-c",
+		String cmd[] = { Global.ffmpegPath, "-f", "concat", "-safe", "0", "-i", Global.savePath + dstName + ".txt", "-c",
 				"copy", Global.savePath + dstName };
 		return cmd;
 	}
@@ -275,15 +268,15 @@ public class CmdUtil {
 	 */
 	public static String[] createConvertCmd(String videoName, String audioName, String dstName) {
 		if (audioName == null) {
-			String cmd[] = { FFMPEG_PATH, "-i", Global.savePath + videoName, "-c", "copy", Global.savePath + dstName };
-			String str = String.format("ffmpeg命令为: \r\n%s -i %s -c copy %s", FFMPEG_PATH, Global.savePath + videoName,
+			String cmd[] = { Global.ffmpegPath, "-i", Global.savePath + videoName, "-c", "copy", Global.savePath + dstName };
+			String str = String.format("ffmpeg命令为: \r\n%s -i %s -c copy %s", Global.ffmpegPath, Global.savePath + videoName,
 					Global.savePath + dstName);
 			Logger.println(str);
 			return cmd;
 		} else {
-			String cmd[] = { FFMPEG_PATH, "-i", Global.savePath + videoName, "-i", Global.savePath + audioName, "-c",
+			String cmd[] = { Global.ffmpegPath, "-i", Global.savePath + videoName, "-i", Global.savePath + audioName, "-c",
 					"copy", Global.savePath + dstName };
-			String str = String.format("ffmpeg命令为: \r\n%s -i %s -i %s -c copy %s", FFMPEG_PATH,
+			String str = String.format("ffmpeg命令为: \r\n%s -i %s -i %s -c copy %s", Global.ffmpegPath,
 					Global.savePath + videoName, Global.savePath + audioName, Global.savePath + dstName);
 			Logger.println(str);
 			return cmd;
@@ -432,7 +425,7 @@ public class CmdUtil {
 
 	/**
 	 * @param paramMap
-	 * @param matcher
+	 * @param formatStr
 	 * @return
 	 */
 	private static String genFormatedName(HashMap<String, String> paramMap, String formatStr) {


### PR DESCRIPTION
## 修复mac上下载视频后无法进行合并问题
### 本地环境：
- java8
- MacBook Pro (13-inch, M1, 2020) 系统版本 Big Sur 11.6 (20G165)
- ffmpeg version 4.4.1 Copyright (c) 2000-2021 the FFmpeg developers
### 问题复现
在我下载了master分支之后，按照Issues上说的进行配置了ffmpeg的绝对路径，在点击下载之后会显示下载异常
![image](https://user-images.githubusercontent.com/32670399/135802815-ecf629bf-a9ea-444b-9cea-32340c5a40a6.png)
### 在idea的console中显示`CmdUtil-run/39 : java.io.IOException: Cannot run program "ffmpeg": error=2, No such file or directory`

![image](https://user-images.githubusercontent.com/32670399/135802900-11d6a74d-b4f8-45f9-99e4-6166843378f9.png)
### 问题原因
Mac终端中运行的程序（软件）需要指定完整路径，就算是配置了环境变量，在执行（exec）时也会因为读取不到软件目录而执行失败，因此一定要指定程序完整路径。
参考博客：[Mac使用java Runtime.getRuntime().exec()执行终端命令](https://blog.csdn.net/yulianpeng/article/details/111601184)

### 修改内容
修改类`CmdUtil`下的所有变量`FFMPEG_PATH`, 替换为`Global.flvUseFFmpeg`